### PR TITLE
Add ~/.local/share/ to shared resource candidates

### DIFF
--- a/source/hostarm_configuration.adb
+++ b/source/hostarm_configuration.adb
@@ -109,8 +109,9 @@ package body HostARM_Configuration is
          when  2 =>  return "/usr/local/share/";
          when  3 =>  return To_String (Home_Path) & "/share/";
          when  4 =>  return To_String (Home_Path) & "/.alire/share/";
-         when  5 =>  return "../share/";
-         when  6 =>  return "./share/";
+         when  5 =>  return To_String (Home_Path) & "/.local/share/";
+         when  6 =>  return "../share/";
+         when  7 =>  return "./share/";
       end case;
    end Share_Candidate_Path;
 

--- a/source/hostarm_configuration.ads
+++ b/source/hostarm_configuration.ads
@@ -61,7 +61,7 @@ package HostARM_Configuration is
                            return Boolean;
    --  See if Path contains the needed directories.
 
-   type Share_Candidate_Index is range 1 .. 6;
+   type Share_Candidate_Index is range 1 .. 7;
    function Share_Candidate_Path (Index : in Share_Candidate_Index)
                                   return String;
    --  Loop around this to get path of possible candidates for shared.


### PR DESCRIPTION
Extends the set of possible shared resource paths with the commonly used ~/.local/share/ directory (aka XDG_DATA_HOME).

Related to #16.